### PR TITLE
Added support for pulling libs and libdirs from Makefile.  Also fixed clean on Windows.

### DIFF
--- a/src/CreateMakefile.js
+++ b/src/CreateMakefile.js
@@ -185,8 +185,12 @@ CXXFLAGS += -feliminate-unused-debug-types
 LDSCRIPT = ${makeInfo.ldscript}
 
 # libraries
-LIBS = -lc -lm -lnosys 
-LIBDIR = 
+LIBS = ${'\\'}
+${createStringList(makeInfo.libs)}
+
+LIBDIR = ${'\\'}
+${createStringList(makeInfo.libdir)}
+
 LDFLAGS = $(MCU) -specs=nosys.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
 
 # default action: build all

--- a/src/CreateMakefile.js
+++ b/src/CreateMakefile.js
@@ -248,7 +248,7 @@ erase: $(BUILD_DIR)/$(TARGET).elf
 # clean up
 #######################################
 clean:
-\t${platform === 'win32' ? '-rm -fR' : '-rm -fR'} $(BUILD_DIR)
+\t${platform === 'win32' ? '-del /q /s' : '-rm -fR'} $(BUILD_DIR)
 	
 #######################################
 # dependencies

--- a/src/Info.js
+++ b/src/Info.js
@@ -123,6 +123,8 @@ export function combineInfo(makefileInfo, fileList, requirementInfo) {
   combineArraysIntoObject(makefileInfo.cIncludes, fileList.cIncludes, 'cIncludes', bundledInfo);
   combineArraysIntoObject(makefileInfo.cxxIncludes, null, 'cxxIncludes', bundledInfo);
   combineArraysIntoObject(makefileInfo.asIncludes, null, 'asIncludes', bundledInfo);
+  combineArraysIntoObject(makefileInfo.libs, null, 'libs', bundledInfo);
+  combineArraysIntoObject(makefileInfo.libdir, null, 'libdir', bundledInfo);
 
   // now assign makelist values
   _.set(bundledInfo, 'target', _.replace(makefileInfo.target, /\s/g, '_'));
@@ -131,6 +133,8 @@ export function combineInfo(makefileInfo, fileList, requirementInfo) {
   _.set(bundledInfo, 'floatAbi', makefileInfo.floatAbi);
   _.set(bundledInfo, 'mcu', makefileInfo.mcu);
   _.set(bundledInfo, 'ldscript', makefileInfo.ldscript);
+  _.set(bundledInfo, 'libs', makefileInfo.libs);
+  _.set(bundledInfo, 'libdir', makefileInfo.libdir);
   _.set(bundledInfo, 'cDefs', makefileInfo.cDefs);
   _.set(bundledInfo, 'cxxDefs', makefileInfo.cxxDefs);
   _.set(bundledInfo, 'asDefs', makefileInfo.asDefs);

--- a/src/MakefileInfo.js
+++ b/src/MakefileInfo.js
@@ -51,6 +51,8 @@ export const makefileInfo = {
   floatAbi: '',
   mcu: '',
   ldscript: '',
+  libs: [],
+  libdir: [],
   cSources: [],
   cxxSources: [],
   asmSources: [],
@@ -158,6 +160,12 @@ export function extractMakefileInfo(infoDef, makefile) {
     if (!info || info.length === 0) return;
     if (info.indexOf('\\') !== -1) {
       infoDef[key] = extractMultiLineInfo(makeFileKey, makefile);
+      if (key == "libs") {
+        // Put a colon after each -l
+        infoDef[key].forEach((line, index) => {infoDef[key][index] = "-l:" + line.slice(2)});
+        // There are -l flags on the first line of libs as well, add them back in
+        infoDef[key].unshift(info.replace(/(\s\\$)|(\s.$)/gim, '').trim());
+      }
     } else {
       infoDef[key] = info;
     }

--- a/test/MakefileInfo/MakefileInfo.test.js
+++ b/test/MakefileInfo/MakefileInfo.test.js
@@ -72,6 +72,8 @@ const cIncludes = [
   '-IDrivers/CMSIS/Include',
   '-IDrivers/CMSIS/Include',
 ];
+const libs = ['-lc -lm -lnosys'];
+const libdir = [''];
 
 const asmSources = ['startup_stm32h743xx.s'];
 const floatAbi = '-mfloat-abi=hard';
@@ -85,6 +87,8 @@ export const makefileInfoTemplate = {
   floatAbi: '',
   mcu: '',
   ldscript: '',
+  libs: [],
+  libdir: [],
   cSources: [],
   cxxSources: [],
   asmSources: [],
@@ -104,6 +108,8 @@ export const makefileInfoTest = {
   floatAbi,
   mcu: '$(CPU) -mthumb $(FPU) $(FLOAT-ABI)',
   ldscript: 'STM32H743ZITx_FLASH.ld',
+  libs: [],
+  libdir: [],
   cSources,
   cxxSources: [],
   asmSources,
@@ -127,11 +133,12 @@ suite('MakefileInfoTest', () => {
     assert.equal(extractSingleLineInfo('C_SOURCES', testMakefile), ' \\');
     assert.equal(extractSingleLineInfo('PREFIX', testMakefile), 'arm-none-eabi-');
     assert.equal(extractSingleLineInfo('CPU', testMakefile), '-mcpu=cortex-m7');
-    assert.equal(extractSingleLineInfo('LIBS', testMakefile), '-lc -lm -lnosys');
   });
   test('extractMultiLineInfo', () => {
-    assert.deepEqual(extractMultiLineInfo('C_DEFS', testMakefile), ['-DUSE_HAL_DRIVER', '-DSTM32H743xx', '-DUSE_HAL_DRIVER', '-DSTM32H743xx']);
+    assert.deepEqual(extractMultiLineInfo('C_DEFS', testMakefile), cDefs);
     assert.deepEqual(extractMultiLineInfo('c_sources', testMakefile), cSources);
+    assert.deepEqual(extractMultiLineInfo('LIBS', testMakefile), libs);
+    assert.deepEqual(extractMultiLineInfo('LIBDIR', testMakefile), libdir);
     assert.deepEqual(extractMultiLineInfo('target', testMakefile), []);
   });
   test('extractMakefileInfo', () => {


### PR DESCRIPTION
I added support for extracting libs and libdirs from the Makefile.  Not sure if this is the right way to do it, but it seems to work, and mirrors the other info as far as I can tell.

A couple weirdnesses that had to be accounted for in the Makefile.  ST adds a few entries to the first line, so those are added back in where they're ignored for the other data types.
ST also adds a colon (':') between -l and the library name in STM32CubeIDE, like 
-l:USBPDCORE_PD3_FULL_CM4_wc32.a
I don't know why, but I'm not a Makefile expert.  It doesn't work without it, for some reason.

I also changed the clean command so that it works on Windows.  Note that the 'rm' command does exist in PowerShell (with different syntax) but doesn't seem to work with GNU Make, so I used 'del' instead.

I also added tests as well as I could, but I couldn't get them to run (can't find HandleIgnoredTasks which is unrelated I think).  I changed the array on Line 133 to cDefs because that was already declared identically up above in the file.