### PR TITLE
ldFlags implementation and #55 fix

### DIFF
--- a/src/CreateMakefile.ts
+++ b/src/CreateMakefile.ts
@@ -216,7 +216,10 @@ LIBS = ${createSingleLineStringList(makeInfo.libs, '-l')}
 LIBDIR = ${'\\'}
 ${createStringList(makeInfo.libdir, '-L')}
 
-LDFLAGS = $(MCU) -specs=nosys.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
+# other flags
+OTHERFLAGS = ${createSingleLineStringList(makeInfo.ldFlags)}
+
+LDFLAGS = $(MCU) $(OTHERFLAGS) -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections
 
 # default action: build all
 all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin

--- a/src/HandleTasks.ts
+++ b/src/HandleTasks.ts
@@ -2,6 +2,7 @@ import 'process';
 
 import { ShellExecution, Task, TaskProcessEndEvent, tasks, workspace, ShellExecutionOptions } from 'vscode';
 const { platform } = process;
+const { arch } = process;
 /**
  *
  * @param type type of process to execute e.g. build
@@ -12,7 +13,7 @@ export default function executeTask(
   type: string, name: string, cmd: string, cwd?: string): Promise<void | number> {
   return new Promise((resolve, reject) => {
     const shellOptions: ShellExecutionOptions = {};
-    if (platform === 'win32') {
+    if (platform === 'win32' && arch !== 'x64') {
       shellOptions.shellArgs = [
         'cmd',
         '/c'
@@ -23,6 +24,7 @@ export default function executeTask(
       shellOptions.cwd = cwd;
     }
     const processExec = new ShellExecution(cmd, shellOptions);
+
     if (!workspace.workspaceFolders) {
       reject(Error('no workspace folder is selected'));
       return;


### PR DESCRIPTION
Couple of things I noticed when converting projects from STM32CubeIDE or SW4STM32 to this extension:
- ldFlags wasn't used in makefile config but gave wanted flexibility (for example for --specs and -u flags);
- The patch for issue #55 broke building on x64 architecture.