### PR TITLE
Fixed error for stm32l0 MCUs

### DIFF
--- a/src/configuration/ConfigInfo.ts
+++ b/src/configuration/ConfigInfo.ts
@@ -6,7 +6,7 @@ export const targetsMCUs = [
   'stm32f4x',
   'stm32f7x',
   'stm32h7x',
-  'stm32l0x',
+  'stm32l0',
   'stm32l1x',
   'stm32l4x',
   'stm32g0x',


### PR DESCRIPTION
Fixed error which caused an OpenOCD upload error for stm32l0 family MCUs  (as described in the [issue](https://github.com/bmd-studio/stm32-for-vscode/issues/125))