### PR TITLE
Issue #143 #147

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,11 +3,8 @@
     {
       "label": "compile extension",
       "type": "shell",
-      // "script": " echo",
       "command": "npm run compile:dev",
-      "options": {
-        // "cwd": "${workspaceRoot}",
-      },
+      "options": {},
       "group": {
         "kind": "build",
         "isDefault": true
@@ -16,16 +13,13 @@
     {
       "label": "compile tests",
       "type": "shell",
-      // "script": " echo",
       "command": "npm run pretest",
-      "options": {
-        // "cwd": "${workspaceRoot}",
-      },
+      "options": {},
       "group": {
         "kind": "build",
         "isDefault": true
       },
       "problemMatcher": "$tsc"
-    },
+    }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,25 @@
 
 ## [Unreleased]
 ### Added
-  - Add support for unit testing.
+	- Add support for unit testing.
+	- Create a way to embed these types of projects into a CI/CD environment
 
-## [3.2.4] - 2023-02-27 
+## [3.2.4] - 2023-03-24 
 ### Fixed
  - Issue #139: Fixed issue where after generation something went wrong with getting new information from the makefile.
  - Better SVD file finding using Levenstein distance.
+ - Issue #147: Fixed issue where build tools were not installing due to pre-installed node.
+### Added
+ - Issue #143: Added support for capitalized assembly file extensions (.S) as it is required for AzureRTOS.
+
 ## [3.2.3] - 2022-11-14 
 ### Addded
-  - Issue #101 & #119: Added make flags to the configuration file. This allows to add the --silent flag to the build and to prevent output mixing on parallel compilation.
+	- Issue #101 & #119: Added make flags to the configuration file. This allows to add the --silent flag to the build and to prevent output mixing on parallel compilation.
 ### Fixed
-  - Issue #116: Fixed issue where the STM32 configuration file would silently delete if there was something wrong while parsing the yaml file.
-  - c_cpp_properties.json would have reflect the current configuration. Changed it so it is regenerated upon each new build.
-  - Issues #125: Issue with the openocd configuration for the STM32l0 line. With thanks to: signorettae.
-  - Issue #91: LIBS variabel in the cube generated makefile was not read correctly.
+	- Issue #116: Fixed issue where the STM32 configuration file would silently delete if there was something wrong while parsing the yaml file.
+	- c_cpp_properties.json would have reflect the current configuration. Changed it so it is regenerated upon each new build.
+	- Issues #125: Issue with the openocd configuration for the STM32l0 line. With thanks to: signorettae.
+	- Issue #91: LIBS variabel in the cube generated makefile was not read correctly.
 ## [3.2.2] - 2022-06-29
 ### Fixed
  - Fixed Issue #96: Fixed issue where debugging for C++ gave no source file error due to missing debugging flags.
@@ -25,7 +30,7 @@
  - Issue #94: Extension will try and find the SVD file for the specific MCU, add it to the workspace folder and add it to the cortex-debug launch configuration.
  - Added attach debug configuration
  - Issue #109: Added custom makefile rule option to the STM32-for-VSCode.config.yaml file which allows for custom makefile rules to be included.
-  
+	
 ## [3.2.1] - 2022-03-08
 ### Fixed
  - Issue #97: Fixed issue where the default values of fpu and float-abi were not correct. These are now left empty and will not be included as compiler flags when not set.
@@ -63,7 +68,7 @@
  - There was an issue with the npx/npm cache which did not have read/write permissions when no earlier version of node was installed. This has been fixed.
 ## [3.1.0] - 2021-06-16
 ### Added
-  - Issue #73: Added support for a separate input definition file in the config file.
+	- Issue #73: Added support for a separate input definition file in the config file.
 ### Changes
  - Added the STM32: prefix to all the STM32 for VSCode commands.
 ## [3.0.7] - 2021-05-22
@@ -72,7 +77,7 @@
  - Issue #70: Launch and tasks configurations are not overwritten anymore when present. 
 ## [3.0.6] - 2021-05-06
 ### Fixed
-  - Issue #65: There were issue with building on linux due to pathing, sudo when installing make. This has been fixed with this update.
+	- Issue #65: There were issue with building on linux due to pathing, sudo when installing make. This has been fixed with this update.
 ## [3.0.5] - 2021-22-04
 ### Fixed
  - Issue #55 persisted. Due to not implementing a fix besides the make command. The pathing issues were also present when using makefile commands like flash and clean.
@@ -142,7 +147,7 @@ On top of this a lot of the internal structure has changes so it should be more 
 ## [2.2.1] - 2020-09-07
 ### Added
  - Issue #11 & Issue #33 : Add support for different programmers.
-  
+	
 ## [2.2.0] - 2020-09-04
 ### Fixed
  - Issue #32: Switched to g++ linker when linking C++ project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8329,9 +8329,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.75.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-			"integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+			"version": "5.76.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+			"integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -14921,9 +14921,9 @@
 			}
 		},
 		"webpack": {
-			"version": "5.75.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-			"integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+			"version": "5.76.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+			"integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",

--- a/src/CreateMakefile.ts
+++ b/src/CreateMakefile.ts
@@ -31,7 +31,7 @@
 
 import 'process';
 
-import {isEmpty, isString, uniq} from 'lodash';
+import { isEmpty, isString, uniq } from 'lodash';
 
 import MakeInfo from './types/MakeInfo';
 import { fsPathToPosix } from './Helpers';
@@ -285,9 +285,11 @@ vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 # list of C objects
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
+
 # list of ASM program objects
-OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
-vpath %.s $(sort $(dir $(ASM_SOURCES)))
+OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(UPPER_CASE_ASM_SOURCES:.S=.o)))
+OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(LOWER_CASE_ASM_SOURCES:.s=.o)))
+vpath %.[s] $(sort $(dir $(ASM_SOURCES)))
 
 $(BUILD_DIR)/%.o: %.cpp ${makefileName} | $(BUILD_DIR) 
 \t$(CXX) -c $(CXXFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@
@@ -298,7 +300,7 @@ $(BUILD_DIR)/%.o: %.cxx ${makefileName} | $(BUILD_DIR)
 $(BUILD_DIR)/%.o: %.c ${makefileName} | $(BUILD_DIR) 
 \t$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
 
-$(BUILD_DIR)/%.o: %.s ${makefileName} | $(BUILD_DIR)
+$(BUILD_DIR)/%.o: %.[sS] ${makefileName} | $(BUILD_DIR)
 \t$(AS) -c $(CFLAGS) $< -o $@
 
 $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) ${makefileName}

--- a/src/HandleTasks.ts
+++ b/src/HandleTasks.ts
@@ -7,6 +7,7 @@ import {
   ShellExecutionOptions,
   TaskScope,
   WorkspaceFolder,
+  ProcessExecution,
 } from 'vscode';
 import { getAutomationShell } from './Helpers';
 

--- a/src/buildTools/installTools.ts
+++ b/src/buildTools/installTools.ts
@@ -45,11 +45,29 @@ export async function xpmInstall(
   }
   const pathToSaveTo = toolsStoragePath.fsPath;
   const nodePath = path.join(npx, '../');
-  const env: { [key: string]: string } = process.env as { [key: string]: string };
+  const pathSeparator = platform === 'win32' ? ';' : ':';
+  let env: { [key: string]: string } = process.env as { [key: string]: string };
+  env = Object.fromEntries(
+    Object.entries(env)
+      .map(([key, value]) => {
+        if (key.includes('npm') || key.toUpperCase().includes('NVM')) {
+          return [key, ''];
+        }
+        return [key, value];
+      })
+  );
   env['XPACKS_SYSTEM_FOLDER'] = pathToSaveTo;
   env['XPACKS_REPO_FOLDER'] = pathToSaveTo;
   env['npm_config_yes'] = `${true}`;
-  env['PATH'] = `${env.PATH}${platform === 'win32' ? ';' : ':'}${nodePath}`;
+  env['PATH'] = env['PATH']
+    .split(pathSeparator)
+    .filter((pathValue) => (!pathValue.includes('node') && !pathValue.includes('nvm')))
+    .join(pathSeparator);
+  env['PATH'] = `${nodePath}${pathSeparator}${env.PATH}`;
+
+  env['npm_config_cache'] = path.join(toolsStoragePath.fsPath, 'cache');
+  env['NODE'] = nodePath;
+
   const execOptions = {
     env,
     cwd: path.join(npx, '../'),
@@ -96,7 +114,7 @@ export async function installMake(toolsStoragePath: vscode.Uri, npx: string): Pr
       executeCmd = makeDefinition.installation.darwin || '';
     } break;
     case "win32": {
-      const win32XPMMakeDefinition = {...makeDefinition};
+      const win32XPMMakeDefinition = { ...makeDefinition };
       win32XPMMakeDefinition.installation.xpm = win32XPMMakeDefinition.installation.windows;
       return xpmInstall(toolsStoragePath, npx, win32XPMMakeDefinition);
     } break;
@@ -281,7 +299,7 @@ export async function getNode(toolsStoragePath: vscode.Uri): Promise<string> {
   } catch (error) {
     vscode.window.showErrorMessage(
       `An error occurred during the node installation process, 
-        please try again or create an issue at: ${GITHUB_ISSUES_URL}, with stating error: ${error}`
+				please try again or create an issue at: ${GITHUB_ISSUES_URL}, with stating error: ${error}`
     );
     throw error;
   }

--- a/src/buildTools/installTools.ts
+++ b/src/buildTools/installTools.ts
@@ -59,8 +59,8 @@ export async function xpmInstall(
   env['XPACKS_SYSTEM_FOLDER'] = pathToSaveTo;
   env['XPACKS_REPO_FOLDER'] = pathToSaveTo;
   env['npm_config_yes'] = `${true}`;
-  env['PATH'] = env['PATH']
-    .split(pathSeparator)
+  env['PATH'] = env?.['PATH']
+    ?.split(pathSeparator)
     .filter((pathValue) => (!pathValue.includes('node') && !pathValue.includes('nvm')))
     .join(pathSeparator);
   env['PATH'] = `${nodePath}${pathSeparator}${env.PATH}`;

--- a/src/getInfo/getFiles.ts
+++ b/src/getInfo/getFiles.ts
@@ -22,7 +22,7 @@
 * SOFTWARE.
 */
 
-import {set, uniq, flattenDeep, intersection, forEach}  from 'lodash';
+import { set, uniq, flattenDeep, intersection, forEach } from 'lodash';
 import * as pth from 'path';
 import * as vscode from 'vscode';
 
@@ -199,7 +199,7 @@ export async function scanForFiles(includedFilesGlob: string[]): Promise<string[
  * @returns array of posix relative sourcefile paths
  */
 export async function getSourceFiles(sourceFileGlobs: string[]): Promise<string[]> {
-  const sourceFileExtensions = ['cpp', 'c', 'a', 's', 'cxx', 'cc'];
+  const sourceFileExtensions = ['cpp', 'c', 'a', 's', 'S', 'cxx', 'cc'];
   const files = await scanForFiles(sourceFileGlobs);
   const sourceFiles = files.filter((file) => {
     const extension = file.split('.').pop();

--- a/src/test/integration/build.test.ts
+++ b/src/test/integration/build.test.ts
@@ -23,7 +23,13 @@ suite('build test', () => {
   });
   test('default build test', async () => {
     // execute the test build.
-    await buildSTM();
+    try {
+
+      await buildSTM();
+    } catch (error) {
+      console.log(error);
+      throw error;
+    }
   }).timeout(120000);
 
   test('do clean build on fresh project test', async () => {

--- a/src/test/integration/build.ts
+++ b/src/test/integration/build.ts
@@ -20,6 +20,7 @@ export function run(): Promise<void> {
 
       try {
         // Run the mocha test
+        mocha.timeout(120000);
         mocha.run(failures => {
           if (failures > 0) {
             e(new Error(`${failures} tests failed.`));

--- a/src/test/workspaces/H753ZI/Makefile
+++ b/src/test/workspaces/H753ZI/Makefile
@@ -68,7 +68,7 @@ Core/Src/system_stm32h7xx.c
 
 # ASM sources
 ASM_SOURCES =  \
-startup_stm32h753xx.s
+startup_stm32h753xx.S
 
 
 #######################################


### PR DESCRIPTION
fix: #issue 147 due to system installed node versions the installation of the build tools failed. This was due to included configurations for several node/npm environment variables. For now removed these together with references to npm/nvm in PATH.
feat: Issue #143: Added support for capitalized assembly file extensions (.S) as it is required for AzureRTOS.