### PR TITLE
Fix openocdPath Setting Comparison

### DIFF
--- a/src/buildTools/index.ts
+++ b/src/buildTools/index.ts
@@ -19,7 +19,7 @@ export function setCortexDebugSettingsInWorkspace(tools: ToolChain): void {
   ) {
     cortexDebugSetting.update('armToolchainPath', tools.armToolchainPath, vscode.ConfigurationTarget.Workspace);
   }
-  if (cortexDebugSetting.get('openocdPath') && cortexDebugSetting.get('openocdPath') !== tools.openOCDPath) {
+  if (cortexDebugSetting.get('openocdPath') && cortexDebugSetting.get('openocdPath') !== tools.openOCDPath.toString()) {
     cortexDebugSetting.update('openocdPath', tools.openOCDPath, vscode.ConfigurationTarget.Workspace);
   }
 }


### PR DESCRIPTION
In my project, every time I opened VSCode, the `cortex-debug.openocdPath` variable was written to my `settings.json` or `.code-workspace` file, even though I had it set in my user `settings.json` file.  

I believe this issue was fixed by changing this comparison.  Previously, `tools.openOCDPath` was an object, and `cortexDebugSetting.get('openocdPath')` returned a string.  This forces the types to be the same so that the actual settings are compared. 