### PR TITLE
fix: ASMM files

### DIFF
--- a/src/CreateMakefile.ts
+++ b/src/CreateMakefile.ts
@@ -174,6 +174,9 @@ ${createStringList(makeInfo.cxxSources)}
 ASM_SOURCES =  ${'\\'}
 ${createStringList(makeInfo.asmSources)}
 
+ASMM_SOURCES = ${'\\'}
+${createStringList(makeInfo.asmmSources)}
+
 
 #######################################
 # binaries
@@ -287,12 +290,13 @@ OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
 
 # list of ASM program objects
-UPPER_CASE_ASM_SOURCES = $(filter %.S,$(ASM_SOURCES))
 LOWER_CASE_ASM_SOURCES = $(filter %.s,$(ASM_SOURCES))
 
-OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(UPPER_CASE_ASM_SOURCES:.S=.o)))
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(LOWER_CASE_ASM_SOURCES:.s=.o)))
-vpath %.s $(sort $(dir $(ASM_SOURCES)))
+vpath %.s $(sort $(dir $(LOWER_CASE_ASM_SOURCES)))
+
+OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASMM_SOURCES:.S=.o)))
+vpath %.S $(sort $(dir $(ASMM_SOURCES)))
 
 $(BUILD_DIR)/%.o: %.cpp ${makefileName} | $(BUILD_DIR) 
 \t$(CXX) -c $(CXXFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@

--- a/src/getInfo/getCubeMakefileInfo.ts
+++ b/src/getInfo/getCubeMakefileInfo.ts
@@ -165,6 +165,7 @@ const makeInfoKeysToMakefileKeys: [keyof CubeMXMakefile, string][] = [
   ['cIncludes', 'C_INCLUDES'],
   ['cSources', 'C_SOURCES'],
   ['asmSources', 'ASM_SOURCES'],
+  ['asmmSources', 'ASMM_SOURCES'],
   ['libdir', 'LIBDIR'],
   ['libs', 'LIBS'],
   ['target', 'TARGET'],

--- a/src/getInfo/index.ts
+++ b/src/getInfo/index.ts
@@ -215,6 +215,7 @@ export async function getInfo(location: string): Promise<MakeInfo> {
     }
   });
   STM32MakeInfo.customMakefileRules = projectConfiguration.customMakefileRules;
+  STM32MakeInfo.asmmSources = cubeMakefileInfo.asmmSources;
 
   // check for CPP project
   const finalInfo = await checkAndConvertCpp(STM32MakeInfo, projectConfiguration);

--- a/src/types/MakeInfo.ts
+++ b/src/types/MakeInfo.ts
@@ -219,6 +219,7 @@ export default class MakeInfo implements MakeInfoInterface {
   public cSources: string[] = [];
   public cxxSources: string[] = [];
   public asmSources: string[] = [];
+  public asmmSources: string[] = [];
   public libdir: string[] = [];
   public libs: string[] = [];
   public tools: ToolChain = new ToolChain();


### PR DESCRIPTION
This patch allows build STM32 projects that use threadx. (resolves #181)
There might be duplicates of ".S" files in STM32Make.make file inside ASM_SOURCES and ASMM_SOURCES variables. 
Unfortunately, it breaks the ability for an extension to auto-search for assembly language files(".S").
However, I don't think that assembly should be autosearched anyway.