### PR TITLE
Add `.vscode/settings.json` with indentation and line length settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.vscode
 out
 dist
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "[javascript][typescript]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+
+        // Auto-Formatting currently disabled in this repo.
+        // "editor.formatOnSave": true,
+        // "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+        "editor.rulers": [120], // 120 chars is the default eslint max length.
+    },
+}


### PR DESCRIPTION
Storing these per-repo settings in the repo itself helps users start development faster and with less friction.

These are factual and non-opinionated settings, which anyone developing the project must set. Thus, they should be included in the repo's configuration. 